### PR TITLE
Warning in `velocity_constraint`

### DIFF
--- a/R/velocity_constraint.R
+++ b/R/velocity_constraint.R
@@ -70,7 +70,7 @@ apply_constraint.velocity_constraint <- function(constraint, particles, pos, vel
   vel_strength <- sqrt(rowSums(vel^2))
   min_constrained <- !(is.na(constraint$vmin) | vel_strength > constraint$vmin)
   max_constrained <- !(is.na(constraint$vmax) | vel_strength < constraint$vmax)
-  problems <- vel_strength == 0 & (min_constrained || max_constrained)
+  problems <- vel_strength == 0 & (min_constrained | max_constrained)
   vel_strength[problems] <- sqrt(rowSums(vel_tmp[problems, , drop = FALSE]^2))
   vel[problems, ] <- vel_tmp[problems, , drop = FALSE]
   vel_modmin <- ifelse(min_constrained, constraint$vmin/vel_strength, 1)


### PR DESCRIPTION
Wit new R Versions (>= 4.2.0), the method
`apply_constraint.velocity_constraint` causes the warning:

In min_constrained || max_constrained :
  'length(x) = 13 > 1' in coercion to 'logical(1)'

The cause is a new handling of logical expression containing `&&` or `||`. A warning is returned if at least one of the left or right argument has a length > 1. 

Minimal example to trigger the warning:
```
a <- c(0,1)
b <- c(2,0)

a > b | a > 0
a > b || a > 0
```